### PR TITLE
add cleanup notebook

### DIFF
--- a/Earthscope2026/cleanup_for_restart.ipynb
+++ b/Earthscope2026/cleanup_for_restart.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d2338bd8-ce56-4c54-aa98-66a0d9241a2b",
+   "metadata": {},
+   "source": [
+    "# Cleanup for Restart\n",
+    "This small notebook can be used to cleanup all outputs created by notebooks run after initial creation of the data set from s3.  The approach is workable because the notebooks generate stacks that are much much smaller than the full data set.  Further, those stacks were intentionally written to gridfs so the `delete_data` method used here will completely clean things out. \n",
+    "\n",
+    "First the stock incantation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "98d410f1-44a4-4128-8698-dcc21f45f7f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mspasspy.db.database import Database\n",
+    "import mspasspy.client as msc\n",
+    "mspass_client = msc.Client()\n",
+    "dask_client = mspass_client.get_scheduler()\n",
+    "db = mspass_client.get_database(\"ES2026\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bce6f232-8464-4951-9ee9-3489fb0346fc",
+   "metadata": {},
+   "source": [
+    "Stacks are all written to wf_TimeSeries with a data_tag.   This next box establishes all data tags. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ae8b5e87-996d-4685-bf5f-95ee63cb9d45",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['simple_stack', 'simple_stack_parallel', 'simple_stack_parallel_scatter_run', 'simple_stack_with_swp']\n"
+     ]
+    }
+   ],
+   "source": [
+    "taglist=db.wf_TimeSeries.distinct(\"data_tag\")\n",
+    "print(taglist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0378c11d-34f0-41bb-be7b-1e8f8ba00443",
+   "metadata": {},
+   "source": [
+    "That confirms only stack data have tags.  Verify content."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cf5c922a-e671-4859-bab0-6c656c8e2883",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "simple_stack 5\n",
+      "simple_stack_parallel 48\n",
+      "simple_stack_parallel_scatter_run 48\n",
+      "simple_stack_with_swp 48\n"
+     ]
+    }
+   ],
+   "source": [
+    "for tag in taglist:\n",
+    "    query={\"data_tag\" : tag}\n",
+    "    nwf = db.wf_TimeSeries.count_documents(query)\n",
+    "    print(tag,nwf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65c835fb-785a-47fc-91d5-8fe9575f20ea",
+   "metadata": {},
+   "source": [
+    "Now the delete loop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "443e5778-ff3e-4f79-80f0-516debd40f42",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleting  5  data with tag= simple_stack\n",
+      "Deleting  48  data with tag= simple_stack_parallel\n",
+      "Deleting  48  data with tag= simple_stack_parallel_scatter_run\n",
+      "Deleting  48  data with tag= simple_stack_with_swp\n"
+     ]
+    }
+   ],
+   "source": [
+    "for tag in taglist:\n",
+    "    query={\"data_tag\" : tag}\n",
+    "    idlist=list()\n",
+    "    cursor = db.wf_TimeSeries.find(query)\n",
+    "    for doc in cursor:\n",
+    "        idlist.append(doc['_id'])\n",
+    "    print(\"Deleting \",len(idlist),\" data with tag=\",tag)\n",
+    "    for id in idlist:\n",
+    "        db.delete_data(id,\"TimeSeries\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9af75bae-e342-4e59-938d-2b71a20c9f3d",
+   "metadata": {},
+   "source": [
+    "Confirm that worked"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "63a26370-d2bf-46ae-a34b-7c91c0ba3368",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "simple_stack 0\n",
+      "simple_stack_parallel 0\n",
+      "simple_stack_parallel_scatter_run 0\n",
+      "simple_stack_with_swp 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "for tag in taglist:\n",
+    "    query={\"data_tag\" : tag}\n",
+    "    nwf = db.wf_TimeSeries.count_documents(query)\n",
+    "    print(tag,nwf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce09aca6-f41f-496c-8c59-93db5518cfa7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This tutorial builds a working data set by downloading continuous waveform data from s3 and converting it into event segments.  That process is not trivial and takes around 30 minutes to complete on geolab.   I'm adding this notebook so students who mess something up or have issues during session2 can clear out debris easily.   The commit adds a single notebook that does that using data tags special to the tutorial workflow.